### PR TITLE
Update getWinVolumeList() to look for drives ranging from A:\ to Z:\

### DIFF
--- a/app/fileutil.py
+++ b/app/fileutil.py
@@ -17,7 +17,7 @@ else:
 
 def getWinVolumeList():
 	vol_list = []
-	for label in range(67, 90):
+	for label in range(65, 91):
 		vol = chr(label) + ':\\'
 		if os.path.isdir(vol):
 			vol_list.append(vol)


### PR DESCRIPTION
Hi! Love this Sublime text plugin. Just an issue.

getWinVolumeList was looking only for drives ranging from C:\ to Y:. I've updated it to look for drives ranging from A:\ to Z:.
