### PR TITLE
Fix  'unable to import a library that had some code in a 'src' subfolder...

### DIFF
--- a/app/sketch.py
+++ b/app/sketch.py
@@ -229,8 +229,9 @@ def expandCoreFolder(lib_folder, platform_name = ''):
 	if not platform_name:
 		platform_name = constant.sketch_settings.get('platform_name', 'General')
 
+	arduino_folder = constant.sketch_settings.get('arduino_folder', '')
 	lib_src_folder = os.path.join(lib_folder, 'src')
-	if not os.path.isdir(lib_src_folder):
+	if not os.path.isdir(lib_src_folder) or (os.path.isdir(lib_src_folder) and not arduino_folder in lib_src_folder ):
 		lib_folder_list.append(lib_folder)
 	else:
 		lib_folder_list.append(lib_src_folder)


### PR DESCRIPTION
Hi, had trouble getting my head around it, but I was unable to import a library that had some code in a 'src' subfolder.

It turns out there is a check in sketch.py, method expandCoreFolder that checks for a subfolder named src, and if so (I imagine because of some particular structure in the core arduino libraries) it skips including the main folder in the list of folders to be checked for include files.
I changed the method so that it checks whether the folder in question is in the arduino application path, and skip this particular behaviour for folders not in there (i.e. the sketchbook libraries folder):
