### PR TITLE
Update arduino_avr.txt

### DIFF
--- a/compile/arduino_avr.txt
+++ b/compile/arduino_avr.txt
@@ -1,4 +1,3 @@
-
 # AVR compile variables
 # --------------------- 
 
@@ -59,7 +58,7 @@ tools.avrdude.config.path.linux={runtime.ide.path}/hardware/tools/avrdude.conf
 
 tools.avrdude.upload.params.verbose=-v -v -v -v
 tools.avrdude.upload.params.quiet=-q -q
-tools.avrdude.upload.pattern="{cmd.path}" "-C{config.path}" {upload.verbose} -p{build.mcu} -c{upload.protocol} -P{serial.port} -b{upload.speed} -D "-Uflash:w:{build.path}/{build.project_name}.hex:i"
+tools.avrdude.upload.pattern="{cmd.path}" "-C{config.path}" {upload.verbose} -p{build.mcu} -c{upload.protocol} "-P{serial.port}" -b{upload.speed} -D "-Uflash:w:{build.path}/{build.project_name}.hex:i"
 
 tools.avrdude.program.params.verbose=-v -v -v -v
 tools.avrdude.program.params.quiet=-q -q


### PR DESCRIPTION
change -P{serial.port} to "-P{serial.port}" to avoid path spaces in some usb2ttl breakouts