### PR TITLE
Allow Full Compilation option to stick...

### DIFF
--- a/app/compiler.py
+++ b/app/compiler.py
@@ -151,7 +151,6 @@ class Compiler:
 					printSizeInfo(self.output_console, stdout, self.args)
 		if self.no_error:
 			self.output_console.printText('[Stino - Done compiling.]\n')
-			constant.sketch_settings.set('full_compilation', False)
 		self.is_finished = True
 			
 def getChosenArgs(arduino_info):


### PR DESCRIPTION
If users don't want to full compile after a sucessful compile they can
uncheck the menu item or use the keyboard shortcut.

I think this is what #117 was hoping for.
