### PR TITLE
New option that lets you use Stino as a bare-metal compiler-and-programming tool.

### DIFF
--- a/StinoStarter.py
+++ b/StinoStarter.py
@@ -14,7 +14,7 @@ else:
 class SketchListener(sublime_plugin.EventListener):
 	def on_activated(self, view):
 		pre_active_sketch = app.constant.global_settings.get('active_sketch', '')
-		
+
 		if not app.sketch.isInEditor(view):
 			return
 
@@ -124,7 +124,7 @@ class CompileSketchCommand(sublime_plugin.WindowCommand):
 		self.window.active_view().run_command('save')
 		cur_folder = app.active_file.getFolder()
 		cur_project = app.sketch.Project(cur_folder)
-		
+
 		args = app.compiler.Args(cur_project, app.arduino_info)
 		compiler = app.compiler.Compiler(app.arduino_info, cur_project, args)
 		compiler.run()
@@ -140,7 +140,7 @@ class UploadSketchCommand(sublime_plugin.WindowCommand):
 		self.window.active_view().run_command('save')
 		cur_folder = app.active_file.getFolder()
 		cur_project = app.sketch.Project(cur_folder)
-		
+
 		args = app.compiler.Args(cur_project, app.arduino_info)
 		compiler = app.compiler.Compiler(app.arduino_info, cur_project, args)
 		compiler.run()
@@ -158,7 +158,7 @@ class UploadUsingProgrammerCommand(sublime_plugin.WindowCommand):
 		self.window.active_view().run_command('save')
 		cur_folder = app.active_file.getFolder()
 		cur_project = app.sketch.Project(cur_folder)
-		
+
 		args = app.compiler.Args(cur_project, app.arduino_info)
 		compiler = app.compiler.Compiler(app.arduino_info, cur_project, args)
 		compiler.run()
@@ -205,7 +205,7 @@ class ChooseBoardOptionCommand(sublime_plugin.WindowCommand):
 			cur_board_option_setting = board_option_settings[board_id]
 			if board_option < len(cur_board_option_setting):
 				has_setted = True
-		
+
 		if not has_setted:
 			platform_list = app.arduino_info.getPlatformList()
 			cur_platform = platform_list[chosen_platform]
@@ -255,7 +255,7 @@ class BurnBootloaderCommand(sublime_plugin.WindowCommand):
 	def run(self):
 		cur_folder = app.active_file.getFolder()
 		cur_project = app.sketch.Project(cur_folder)
-		
+
 		args = app.compiler.Args(cur_project, app.arduino_info)
 		bootloader = app.uploader.Bootloader(cur_project, args)
 		bootloader.burn()
@@ -426,7 +426,7 @@ class ArchiveSketchCommand(sublime_plugin.WindowCommand):
 			chosen_folder = self.folder_list[index]
 			chosen_folder = chosen_folder.split('(')[1]
 			chosen_folder = chosen_folder[:-1]
-			
+
 			source_folder = app.active_file.getFolder()
 			sketch_name = app.active_file.getSketchName()
 			zip_file_name = sketch_name + '.zip'
@@ -553,7 +553,7 @@ class SetGlobalSettingCommand(sublime_plugin.WindowCommand):
 		if app.active_file.isSrcFile():
 			global_settings = not app.constant.global_settings.get('global_settings', True)
 			app.constant.global_settings.set('global_settings', global_settings)
-		
+
 			if global_settings:
 				folder = app.constant.stino_root
 			else:
@@ -600,6 +600,15 @@ class ShowUploadOutputCommand(sublime_plugin.WindowCommand):
 
 	def is_checked(self):
 		state = app.constant.sketch_settings.get('show_upload_output', False)
+		return state
+
+class SetBareGccOnlyCommand(sublime_plugin.WindowCommand):
+	def run(self):
+		set_bare_gcc_only = not app.constant.sketch_settings.get('set_bare_gcc_only', False)
+		app.constant.sketch_settings.set('set_bare_gcc_only', set_bare_gcc_only)
+
+	def is_checked(self):
+		state = app.constant.sketch_settings.get('set_bare_gcc_only', False)
 		return state
 
 class VerifyCodeCommand(sublime_plugin.WindowCommand):

--- a/app/compiler.py
+++ b/app/compiler.py
@@ -61,14 +61,14 @@ class Command:
 			output_console.printText(message)
 
 		cur_command = formatCommand(self.command)
-		compile_proc = subprocess.Popen(cur_command, stdout = subprocess.PIPE, 
+		compile_proc = subprocess.Popen(cur_command, stdout = subprocess.PIPE,
 			stderr = subprocess.PIPE, shell = True)
 		result = compile_proc.communicate()
 		return_code = compile_proc.returncode
 		stdout = result[0].decode(constant.sys_encoding).replace('\r', '')
 		stderr = result[1].decode(constant.sys_encoding).replace('\r', '')
 		self.stdout = stdout
-		
+
 		show_compilation_output = constant.sketch_settings.get('show_compilation_output', False)
 		if show_compilation_output:
 			output_console.printText(self.command)
@@ -76,7 +76,7 @@ class Command:
 			output_console.printText(stdout)
 		output_console.printText(stderr)
 		return return_code
-			
+
 	def isSizeCommand(self):
 		return self.calc_size
 
@@ -127,7 +127,7 @@ class Compiler:
 		self.command_list = []
 		if self.args:
 			self.command_list = genCommandList(self.args, self.cur_project, self.arduino_info)
-	
+
 	def run(self):
 		if self.command_list:
 			compilation_thread = threading.Thread(target=self.compile)
@@ -153,7 +153,7 @@ class Compiler:
 			self.output_console.printText('[Stino - Done compiling.]\n')
 			constant.sketch_settings.set('full_compilation', False)
 		self.is_finished = True
-			
+
 def getChosenArgs(arduino_info):
 	args = {}
 	platform_list = arduino_info.getPlatformList()
@@ -392,7 +392,7 @@ def getCoreFolder(arduino_info):
 		constant.sketch_settings.set('platform', platform_id)
 		constant.sketch_settings.set('platform_name', platform_name)
 	platform = platform_list[platform_id]
-	
+
 	core_folder = ''
 	core_folder_list = platform.getCoreFolderList()
 	for cur_core_folder in core_folder_list:
@@ -515,7 +515,7 @@ def getLibFolderListFromProject(cur_project, arduino_info):
 	selected_platform = platform_list[platform_id]
 	general_h_lib_dict = general_platform.getHLibDict()
 	selected_h_lib_dict = selected_platform.getHLibDict()
-	
+
 	ino_src_file_list = cur_project.getInoSrcFileList()
 	c_src_file_list = cur_project.getCSrcFileList()
 	h_list = preprocess.getHListFromSrcList(ino_src_file_list + c_src_file_list)
@@ -536,7 +536,10 @@ def genBuildCppFile(build_folder, cur_project, arduino_info):
 	cpp_file = os.path.join(build_folder, cpp_file_name)
 	ino_src_file_list = cur_project.getInoSrcFileList()
 	arduino_version = arduino_info.getVersion()
-	preprocess.genCppFileFromInoFileList(cpp_file, ino_src_file_list, arduino_version)
+
+	doMunge = not constant.sketch_settings.get('set_bare_gcc_only', False)
+	preprocess.genCppFileFromInoFileList(cpp_file, ino_src_file_list, arduino_version, preprocess=doMunge)
+
 	return cpp_file
 
 def genIncludesPara(build_folder, project_folder, core_folder_list, compiler_include_folder):
@@ -669,7 +672,7 @@ def genCommandList(args, cur_project, arduino_info):
 	includes_para = genIncludesPara(build_folder, project_folder, core_folder_list, compiler_include_folder)
 	project_C_file_list = [build_cpp_file] + cur_project.getCSrcFileList()
 	core_C_file_list = sketch.getCSrcFileListFromFolderList(core_folder_list)
-	
+
 	project_command_list = getCompileCommandList(project_C_file_list, args, includes_para)
 	core_command_list = getCompileCommandList(core_C_file_list, args, includes_para)
 	ar_command = getArCommand(args, core_command_list)
@@ -677,7 +680,7 @@ def genCommandList(args, cur_project, arduino_info):
 	eep_command = getEepCommand(args)
 	hex_command = getHexCommand(args)
 	size_command = getSizeCommand(args)
-	
+
 	full_compilation = constant.sketch_settings.get('full_compilation', True)
 	archive_file_name = args['archive_file']
 	archive_file = os.path.join(build_folder, archive_file_name)

--- a/app/menu.py
+++ b/app/menu.py
@@ -15,7 +15,7 @@ class MainMenu:
 		self.arduino_info = arduino_info
 		self.menu = MenuItem('Main Menu')
 		self.refresh()
-		
+
 	def getMenu(self):
 		return self.menu
 
@@ -250,7 +250,7 @@ def buildProgrammerMenu(language, arduino_info):
 		platform_list = arduino_info.getPlatformList()
 		if platform_id < len(platform_list):
 			platform = platform_list[platform_id]
-				
+
 			programmer_list = platform.getProgrammerList()
 			if programmer_list:
 				for cur_programmer in programmer_list:
@@ -361,6 +361,7 @@ def buildSettingMenu(language):
 	change_build_folder_menu = MenuItem(language.translate('Select Build Folder'))
 	change_build_folder_menu.setCommand('choose_build_folder')
 
+
 	language_menu = buildLanguageMenu(language)
 
 	setting_menu.addMenuItem(select_arduino_folder_menu)
@@ -405,7 +406,7 @@ def buildReferenceMenu(language):
 	references_menu.addMenuItem(find_menu)
 	references_menu.addMenuItem(faq_menu)
 	references_menu.addMenuItem(website_menu)
-	return references_menu	
+	return references_menu
 
 def buildSketchMenuGroup(language, arduino_info):
 	new_sketch_menu = MenuItem(language.translate('New Sketch'))
@@ -492,6 +493,7 @@ def buildToolsMenuGroup(language):
 def buildSettingMenuGroup(language):
 	setting_menu_group = MenuItemGroup()
 	setting_menu = buildSettingMenu(language)
+
 	global_setting_menu = MenuItem(language.translate('Global Setting'))
 	global_setting_menu.setCommand('set_global_setting')
 	global_setting_menu.setCheckbox()
@@ -500,22 +502,30 @@ def buildSettingMenuGroup(language):
 	full_compilation_menu.setCommand('set_full_compilation')
 	full_compilation_menu.setCheckbox()
 
-	show_verbose_output_menu = MenuItem(language.translate('Show Verbose Output'))
+
+	bare_gcc_only_menu = MenuItem(language.translate('Bare GCC Build (No Arduino code-munging)'))
+	bare_gcc_only_menu.setCommand('set_bare_gcc_only')
+	bare_gcc_only_menu.setCheckbox()
+
 	show_compilation_menu = MenuItem(language.translate('Compilation'))
 	show_compilation_menu.setCommand('show_compilation_output')
 	show_compilation_menu.setCheckbox()
+
 	show_upload_menu = MenuItem(language.translate('Upload'))
 	show_upload_menu.setCommand('show_upload_output')
 	show_upload_menu.setCheckbox()
+
+	show_verbose_output_menu = MenuItem(language.translate('Show Verbose Output'))
 	show_verbose_output_menu.addMenuItem(show_compilation_menu)
 	show_verbose_output_menu.addMenuItem(show_upload_menu)
 
 	verify_code_menu = MenuItem(language.translate('Verify Code after Upload'))
 	verify_code_menu.setCommand('verify_code')
 	verify_code_menu.setCheckbox()
-	
+
 	setting_menu_group.addMenuItem(setting_menu)
 	setting_menu_group.addMenuItem(global_setting_menu)
+	setting_menu_group.addMenuItem(bare_gcc_only_menu)
 	setting_menu_group.addMenuItem(full_compilation_menu)
 	setting_menu_group.addMenuItem(show_verbose_output_menu)
 	setting_menu_group.addMenuItem(verify_code_menu)
@@ -539,7 +549,8 @@ def buildPreferenceMenu(language):
 	show_arduino_menu = MenuItem(language.translate('Show Arduino Menu'))
 	show_arduino_menu.setCommand('show_arduino_menu')
 	show_arduino_menu.setCheckbox()
-	
+
+
 	preference_menu.addMenuItem(show_arduino_menu)
 	return preference_menu
 
@@ -610,4 +621,4 @@ def convertMenuToData(cur_menu, level = 0):
 			if checkbox:
 				data['checkbox'] = checkbox
 	return data
-		
+

--- a/app/preprocess.py
+++ b/app/preprocess.py
@@ -160,39 +160,49 @@ def getInsertText(src_file_list):
 	insert_text += '\n'
 	return insert_text
 
-def genCppFileFromInoFileList(cpp_file, ino_src_file_list, arduino_version):
+def genCppFileFromInoFileList(cpp_file, ino_src_file_list, arduino_version, preprocess=True):
 	cpp_text = ''
 
-	if arduino_version < 100:
-		include_text = '#include <WProgram.h>\n'
-	else:
-		include_text = '#include <Arduino.h>\n'
-
-	cpp_text += include_text
-
-	if ino_src_file_list:
-		insert_text = getInsertText(ino_src_file_list)
-		main_src_file = ino_src_file_list[0]
-		src_text = fileutil.readFile(main_src_file)
-
-		function_list = genFunctionList(src_text)
-		if function_list:
-			first_function = function_list[0]
-			index = src_text.index(first_function)
-			header_text = src_text[:index]
-			body_text = src_text[index:]
+	if preprocess:
+		if arduino_version < 100:
+			include_text = '#include <WProgram.h>\n'
 		else:
-			index = len(src_text)
-			header_text = src_text
-			body_text = ''
-		
-		cpp_text += header_text
-		cpp_text += insert_text
-		cpp_text += body_text
+			include_text = '#include <Arduino.h>\n'
 
-		for src_file in ino_src_file_list[1:]:
-			src_text = fileutil.readFile(src_file)
-			cpp_text += src_text
+		cpp_text += include_text
+
+		if ino_src_file_list:
+			insert_text = getInsertText(ino_src_file_list)
+			main_src_file = ino_src_file_list[0]
+			src_text = fileutil.readFile(main_src_file)
+
+			function_list = genFunctionList(src_text)
+			if function_list:
+				first_function = function_list[0]
+				index = src_text.index(first_function)
+				header_text = src_text[:index]
+				body_text = src_text[index:]
+			else:
+				index = len(src_text)
+				header_text = src_text
+				body_text = ''
+
+			cpp_text += header_text
+			cpp_text += insert_text
+			cpp_text += body_text
+
+			for src_file in ino_src_file_list[1:]:
+				src_text = fileutil.readFile(src_file)
+				cpp_text += src_text
+
+	# Don't do any preprocessing at all
+	else:
+
+		if len(ino_src_file_list) != 1:
+			raise ValueError("Too many source files! Only one \".ino\" file is supported")
+
+		main_src_file = ino_src_file_list[0]
+		cpp_text = fileutil.readFile(main_src_file)
 
 	fileutil.writeFile(cpp_file, cpp_text)
 


### PR DESCRIPTION
I really like the arduino toolchain for being dead easy to use, but occationally I want to be able to manage _all_ my interrupts without the arduino stuff getting in the way.

As such, I've added a menu option that lets you use Stino as a simple compile&load tool, rather then the whole arduino affair with automatically-enabled interrupts and such.

![untitled](https://f.cloud.github.com/assets/1401239/2119539/a0b9d104-9172-11e3-8c26-db72a5fe0002.png)
