### PR TITLE
Compile error "{build_core_path}" should be "{build.core.path}"

### DIFF
--- a/preset/platform_teensy3.txt
+++ b/preset/platform_teensy3.txt
@@ -64,7 +64,7 @@ recipe.S.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.S.flags} -mmcu={b
 recipe.ar.pattern="{compiler.path}{compiler.ar.cmd}" {compiler.ar.flags} {compiler.ar.extra_flags} "{build.path}/{archive_file}" "{object_file}"
 
 ## Combine gc-sections, archives, and objects
-recipe.c.combine.pattern="{compiler.path}{compiler.c.elf.cmd}" {compiler.c.elf.flags} -mcpu={build.cpu} {build.linkoption1} "-T{build_core_path}/{build.linkscript}" -o "{build.path}/{build.project_name}.elf" {object_files} "{build.path}/{archive_file}" "-L{build.path}" {build.additionalobject1} -lm -gcc
+recipe.c.combine.pattern="{compiler.path}{compiler.c.elf.cmd}" {compiler.c.elf.flags} -mcpu={build.cpu} {build.linkoption1} "-T{build.core.path}/{build.linkscript}" -o "{build.path}/{build.project_name}.elf" {object_files} "{build.path}/{archive_file}" "-L{build.path}" {build.additionalobject1} -lm -gcc
 
 ## Create eeprom
 recipe.objcopy.eep.pattern="{compiler.path}{compiler.objcopy.cmd}" {compiler.objcopy.eep.flags} {compiler.objcopy.eep.extra_flags} "{build.path}/{build.project_name}.elf" "{build.path}/{build.project_name}.eep"


### PR DESCRIPTION
Error on compilation using the Teensy3 board "[...]arm-none-eabi/bin/ld: cannot open linker script file {build_core_path}/mk20dx128.ld: No such file or directory".
This seems to fix it. :)
