### PR TITLE
Update base.py for working with several arduino versions

### DIFF
--- a/app/base.py
+++ b/app/base.py
@@ -281,7 +281,13 @@ class Keyword:
 
 def getRealArduinoPath(folder):
 	if constant.sys_platform == 'osx':
-		folder = os.path.join(folder, 'Contents/Resources/Java')
+		folder_test1 = os.path.join(folder, 'Contents/Resources/Java')
+		folder_test2 = os.path.join(folder, 'Contents/Java')
+
+		if os.path.exists(folder_test1):
+			folder = folder_test1
+		elif os.path.exists(folder_test2):
+			folder = folder_test2
 	return folder
 
 def isArduinoFolder(folder):


### PR DESCRIPTION
The update allows several Arduino IDE versions to be selectable from  the Arduino->Preferences->Select Arduino Application Folder in Mac OS. For example, Arduino IDE 1.0.5 and Arduino IDE 1.5.8 can be selected. In some cases, the two arduino IDE versions are required due to custom board inclusions that are not compatible with both versions.