### PR TITLE
Assume new library layout if 'library.properties' is present (issue #272)

### DIFF
--- a/stino/pyarduino/arduino_library.py
+++ b/stino/pyarduino/arduino_library.py
@@ -52,8 +52,9 @@ class LibrarySet(base.abs_file.Dir):
 class Library(base.abs_file.Dir):
     def __init__(self, path):
         super(Library, self).__init__(path)
-        self.src_path = os.path.join(self.path, 'src')
-        if not os.path.isdir(self.src_path):
+        if os.path.isfile(os.path.join(self.path, 'library.properties')):
+            self.src_path = os.path.join(self.path, 'src')
+        else:
             self.src_path = self.path
         self.src_dir = base.abs_file.Dir(self.src_path)
 


### PR DESCRIPTION
[ArduinoJson](https://github.com/bblanchon/ArduinoJson) contains a `src/` folder, but its primary `.cpp` file is in the root folder.
This confuses Stino because it doesn't find the primary `.cpp` in the `src/` folder.

I changed the code to check if `library.properties` is present, which is required for the new layout.
See [Arduino 1.5 library format (rev. 2)](https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#15-library-format-rev-2)