### PR TITLE
fixes issue 278

### DIFF
--- a/Comments.tmPreferences
+++ b/Comments.tmPreferences
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
    <key>name</key>


### PR DESCRIPTION
Package Folder would get deleted immediately after installation and Sublime restart, this seems to fix it, tested on Mac OS X 10.10.3 and Sublime Text Stable Channel 3083