### PR TITLE
New stino teensy support

### DIFF
--- a/stino/pyarduino/arduino_compiler.py
+++ b/stino/pyarduino/arduino_compiler.py
@@ -265,11 +265,20 @@ class Compiler(object):
 
         ide_path = self.arduino_info.get_ide_dir().get_path()
 
+        # TEENSY BUILD UPDATEBuild Time - 
+        self.params['extra.time.local'] = str(int(time.time()))
+        platform_path = self.params.get('runtime.platform.path', '')
+        hardware_path = os.path.dirname(platform_path)
+        self.params['runtime.hardware.path'] = hardware_path
+        # END TEENSY
         if not 'compiler.path' in self.params:
             compiler_path = '{runtime.ide.path}/hardware/tools/avr/bin/'
             self.params['compiler.path'] = compiler_path
         compiler_path = self.params.get('compiler.path')
         compiler_path = compiler_path.replace('{runtime.ide.path}', ide_path)
+        # TEENSY BUILD UPDATEBuild Time - 
+        compiler_path = compiler_path.replace('{runtime.hardware.path}', hardware_path)
+        # END TEENSY
 
         if not os.path.isdir(compiler_path):
             self.params['compiler.path'] = ''

--- a/stino/pyarduino/arduino_compiler.py
+++ b/stino/pyarduino/arduino_compiler.py
@@ -293,6 +293,9 @@ class Compiler(object):
         combine_cmd = self.params.get('recipe.c.combine.pattern', '')
         eep_cmd = self.params.get('recipe.objcopy.eep.pattern', '')
         hex_cmd = self.params.get('recipe.objcopy.hex.pattern', '')
+        # TEENSY BUILD TYQT
+        tyqt_cmd = self.params.get('recipe.objcopy.tyqt.pattern', '')
+        # END TEENSY
 
         self.build_files = []
         self.file_cmds_dict = {}
@@ -356,6 +359,16 @@ class Compiler(object):
                 hex_file_path = project_file_base_path + ext
                 self.build_files.append(hex_file_path)
                 self.file_cmds_dict[hex_file_path] = [hex_cmd]
+
+            # TEENSY BUILD TYQT
+            if tyqt_cmd:
+                ext = '.bin'
+                if '.hex' in tyqt_cmd:
+                    ext = '.hex'
+                tyqt_file_path = project_file_base_path + ext
+                self.build_files.append(tyqt_file_path)
+                self.file_cmds_dict[hex_file_path] = [tyqt_cmd]
+                # END TEENSY
 
     def exec_build_cmds(self):
         show_compilation_output = self.settings.get('build_verbose', False)

--- a/stino/pyarduino/arduino_library.py
+++ b/stino/pyarduino/arduino_library.py
@@ -52,7 +52,9 @@ class LibrarySet(base.abs_file.Dir):
 class Library(base.abs_file.Dir):
     def __init__(self, path):
         super(Library, self).__init__(path)
-        if os.path.isfile(os.path.join(self.path, 'library.properties')):
+        ##if os.path.isfile(os.path.join(self.path, 'library.properties')):
+        if os.path.isdir(os.path.join(self.path, 'src')):
+
             self.src_path = os.path.join(self.path, 'src')
         else:
             self.src_path = self.path


### PR DESCRIPTION
Fix some issues associated with using Stino to build for Teensy boards. 

This includes adding params needed by the Teensy3 platform.txt:
    runtime.hardware.path
    extra.time.local

Also brought in the fix suggested in issue #330, which allowed the build to find libraries where the Teensyduino install put them:
<your build>\hardware\teensy\avr\libraries

Also Added some support to make it work if you would integrate in to use TyQt to do the uploads.  It defined a new recipe:
recipe.objcopy.tyqt.pattern, which normal arduino builds picks up but Stino was not.  So looked for it specifically and if found do it...

The one change I still have to make to the platform.txt file is for the recipe.ar.pattern, where I change: 
    recipe.ar.pattern="{compiler.path}{build.toolchain}{build.command.ar}" rcs "{build.path}/core/{archive_file}" "{object_file}"

TO:
    archive_file_path={build.path}/{archive_file}
    recipe.ar.pattern="{compiler.path}{build.toolchain}{build.command.ar}"  rcs "{archive_file_path}" "{object_file}"

Which is more consistent with with the standard AVR platform.txt and works fine in Arduino build as well.  Will see about getting this changed in hopefully the next Teensyduino install
